### PR TITLE
Rewrite slides for kata 1

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -178,8 +178,13 @@ Since `todoElements` is an expression, we can include it inside our `View`, inst
 
 ---
 # Keys in loops
-Components rendered with loops require a `key` property that identifies them.
-Keys are important for react to be able to understand which views have been added, removed or altered. Use `todo.name` as a key for now.
+
+If you reloaded, you'll notice there's a small yellow warning on the bottom of the app. Components rendered with loops require a `key` property that identifies them.
+Keys are important for react to be able to understand which views have been added, removed or altered.
+
+> As you can do inside a component, you can use `propName={expression}` to pass properties. If it's a hardcoded string, prefer `propName="value"`.
+
+Before moving to the next step, let's use `todo.name` as a key for our elements.
 
 ---
 # Conventions

--- a/slides.md
+++ b/slides.md
@@ -166,7 +166,7 @@ const todos = [{
 ];
 ```
 
-Inside `render()`, you can then map those TODOs to a certain element:
+The `render` method must return a hierarchy of views that we want to display. We can `map` our todos to views inside that method.
 
 ```javascript
 const todoElements = todos.map(todo => <Text>{todo.name}</Text>);

--- a/slides.md
+++ b/slides.md
@@ -199,7 +199,8 @@ const Hello = ({name}) => (
 );
 ```
 
-> The component will receive a parameter represented the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
+> The component will receive a parameter containing the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
+
 > You can the use the component importing it (if it was declared it in another file, remember to export it!) and using it as any other component.
 
 ```javascript

--- a/slides.md
+++ b/slides.md
@@ -214,7 +214,7 @@ Extract a `TodoItem` component, that accepts a `name` parameter, and substitute 
 
 ---
 # Lists
-Our TODO list is coming up quite well, but it won't scroll!
+Our TODO list is coming together quite well, but it won't scroll!
 
 There are a few possible solutions to it:
 

--- a/slides.md
+++ b/slides.md
@@ -213,14 +213,22 @@ Extract a `TodoItem` component, that accepts a `name` parameter, and substitute 
 
 ---
 # Lists
-Our todo list is coming up quite well, but it won't scroll! We could use `ScrollView`, but then all our todos would be rendered at the same time, even the ones off screen.
-To render arbitrary amount of data, we can use `FlatList`.
-`FlatList` accepts these (and more) parameters:
-1. `data`: is our array of todos
-2. `renderItem`: this is a function which will return a component, it receives an object containing the keys `item` (our todo, in this case) and `index`.
-Rewrite the array mapping with `FlatList`.
+Our todo list is coming up quite well, but it won't scroll!
 
-Extract the list inside a `TodoList` component.
+There are a few possible solution to it:
+
+1. Using `ScrollView` instead of our `View` element would make it scrollable.
+2. Using `FlatList`, a similar concept to `RecyclerView` on Android and `UICollectionView` on iOS.
+
+`ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want it to be rendered when on screen. We will go with `FlatList`.
+
+> `FlatList` accepts various parameters, in our case we're interested in `data`, which is a list of items to render (our todos), and `renderItem`, which is a callback to render our `Todo` item.
+
+> `renderItem` receives an object containing 2 keys: `item` and `index`, representing the current item in the list and its index, and must return a tree of elements.
+
+We could reuse the same function we used with `todos.map()` earlier, as long as we change how we access the todos (the parameters are inside an object, you can destructure to access them directly).
+
+Extract a `TodoList` element, that accepts a property `todos`, a list of todos, and uses `FlatList` to render `TodoItem`s.
 
 ---
 # Lists - Keys

--- a/slides.md
+++ b/slides.md
@@ -188,12 +188,27 @@ Before moving to the next step, let's use `todo.name` as a key for our elements.
 
 ---
 # Abstracting away
-The app looks amazing! But it would be great to have a component `Todo` instead of using `Text`. The simplest components can be functions that accept properties and return other components, strings or `null`. Pay attention to the brackets for the function, we'll go over that next.
+
+Now that our single todo is well isolated, we can extract it to a separate component.
+
+> The simplest component is a function that returns a tree of elements. It must have no side effects and return the same result given the same input.
+
 ```javascript
-export const MyComponent = ({name}) => <Text>Hello {name}!</Text>;
-<MyComponent name="Daniele" /> // Somewhere in the app
+const Hello = ({name}) => (
+  <Text>Hello {name}!</Text>
+);
 ```
-You can reference JS variables using `{curlyBraces}`.
+
+> The component will receive a parameter represented the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
+> You can the use the component importing it (if it was declared it in another file, remember to export it!) and using it as any other component.
+
+```javascript
+<Hello name="Daniele" />
+```
+
+> Note that in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self closing, and terminates with `/>` instead of just `>`.
+
+Extract a `TodoItem` component, that accepts a `name` parameter, and substitute the `Text`s with it.
 
 ---
 # ({a, b, c})?!?

--- a/slides.md
+++ b/slides.md
@@ -211,13 +211,6 @@ const Hello = ({name}) => (
 Extract a `TodoItem` component, that accepts a `name` parameter, and substitute the `Text`s with it.
 
 ---
-# ({a, b, c})?!?
-To write an anonymous function in JS, you can use `const add = (p2, p2) => { return p1 + p2; }`. There are some tricks to make it easier to write though.
-- Instead of having the body, you can directly return an expression `(p1, p2) => p1 + p2`
-- If your parameter is an object, you can directly reference its keys with `{k1, k2}`.
-- React Components receive an object called `properties`, containing the attributes we pass to the component when we use it: `<MyComponent name="Daniele" />`.
-
----
 # Lists
 Our todo list is coming up quite well, but it won't scroll! We could use `ScrollView`, but then all our todos would be rendered at the same time, even the ones off screen.
 To render arbitrary amount of data, we can use `FlatList`.

--- a/slides.md
+++ b/slides.md
@@ -156,14 +156,25 @@ import anotherFunction, {aFunction} from "./someFile";
 
 ---
 # Hello Todo!
-1. Edit `App.js` so that the list rendered from an array:
+Currently `App.js` is quite boring, it would be great if instead of having the todos hardcoded, we could somehow cycle through an array of todos and show a `Text` per element.
+
+First of all, we need to extract the data for the todos, in `App.js`:
 ```javascript
 const todos = [{
     name: "Take the dog out",
-  }, ...
+  }, // ...
 ];
 ```
-You can use `todos.map()` to return a component, return a `Text` component showing `todo.name`.
+
+Inside `render()`, you can then map those todos to a certain element:
+
+```javascript
+const todoElements = todos.map(todo => <Text>{todo.name}</Text>);
+```
+
+> Inside a component you can include a JS expression with `{expression}`, in this case `{todo.name}`.
+
+Since `todoElements` is an expression, we can include it inside our `View`, instead of the 3 `Text` elements, remember to use `{}`!
 
 ---
 # Keys in loops

--- a/slides.md
+++ b/slides.md
@@ -235,7 +235,7 @@ Extract a `TodoList` element, that accepts a property `todos`, a list of TODOs, 
 ---
 # Lists - Keys
 
-You should now have another warning: `FlatList` needs to figure out the object key somehow. There are 2 ways of solving this.
+You should now have another warning: `FlatList` needs to somehow figure out the object key. There are 2 ways of solving this.
 
 1. Add a unique `key` field to each one of our TODOs (the data).
 

--- a/slides.md
+++ b/slides.md
@@ -172,7 +172,7 @@ Inside `render()`, you can then map those todos to a certain element:
 const todoElements = todos.map(todo => <Text>{todo.name}</Text>);
 ```
 
-> Inside a component you can include a JS expression with `{expression}`, in this case `{todo.name}`.
+> Inside a component you can include a JS expression with `{expression}`, in this case, `{todo.name}`.
 
 Since `todoElements` is an expression, we can include it inside our `View`, instead of the 3 `Text` elements, remember to use `{}`!
 
@@ -208,20 +208,20 @@ To pass props to a component, add them as an attribute when you use it.
 <Hello name="Daniele" />
 ```
 
-> Note that, in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self closing, and terminates with `/>` instead of just `>`.
+> Note that, in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self-closing, and terminates with `/>` instead of just `>`.
 
 Extract a `TodoItem` component, that accepts a `name` parameter, and substitute the `Text`s with it.
 
 ---
 # Lists
-Our todo list is coming up quite well, but it won't scroll!
+Our to-do list is coming up quite well, but it won't scroll!
 
 There are a few possible solutions to it:
 
 1. Using `ScrollView` instead of our `View` element would make it scrollable.
 2. Using `FlatList`, a similar concept to `RecyclerView` on Android and `UICollectionView` on iOS.
 
-`ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want to render only the components that are visible on screen. We will go with `FlatList`.
+`ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want to render only the components that are visible on the screen. We will go with `FlatList`.
 
 `FlatList` accepts various properties, we will focus on 2 of them:
 

--- a/slides.md
+++ b/slides.md
@@ -269,7 +269,7 @@ Now, let's add that to our properties in `Todo`, and let's use a `Switch` to dis
 
 ---
 # State - getting and initial
-To make the `Switch` work, we need to **change the state of our app**. React class components can be stateful, which means the `App` component can hold its state and React to events.
+To make the `Switch` work, we need to **change the state of our app**. React class components can be stateful, which means the `App` component can hold its state and react to events.
 
 To access the state in a component, you can use `this.state`. This means our `App` component can pass the TODO list as a property to `TodoList`, receiving it from the state.
 

--- a/slides.md
+++ b/slides.md
@@ -201,7 +201,7 @@ const Hello = ({name}) => (
 
 > The component will receive a parameter containing the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
 
-> You can the use the component importing it (if it was declared it in another file, remember to export it!) and using it as any other component.
+> You can then use the component importing it (if it was declared it in another file, remember to export it!) and using it as any other component.
 
 ```javascript
 <Hello name="Daniele" />

--- a/slides.md
+++ b/slides.md
@@ -180,7 +180,7 @@ Since `todoElements` is an expression, we can include it inside our `View`, inst
 # Keys in loops
 
 If you reloaded, you'll notice there's a small yellow warning on the bottom of the app. Components rendered with loops require a `key` property that identifies them.
-Keys are important for react to be able to understand which views have been added, removed or altered.
+Keys are important for React to be able to understand which views have been added, removed or altered.
 
 As you can do inside a component, you can use `propName={expression}` to pass properties. If it's a hardcoded string, prefer `propName="value"`.
 
@@ -269,7 +269,7 @@ Now, let's add that to our properties in `Todo`, and let's use a `Switch` to dis
 
 ---
 # State - getting and initial
-To make the `Switch` work, we need to **change the state of our app**. React class components can be stateful, which means the `App` component can hold its state and react to events.
+To make the `Switch` work, we need to **change the state of our app**. React class components can be stateful, which means the `App` component can hold its state and React to events.
 
 To access the state in a component, you can use `this.state`. This means our `App` component can pass the todo list as a property to `TodoList`, receiving it from the state.
 

--- a/slides.md
+++ b/slides.md
@@ -222,9 +222,10 @@ There are a few possible solutions to it:
 
 `ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want to render only the components that are visible on screen. We will go with `FlatList`.
 
-> `FlatList` accepts various parameters, in our case we're interested in `data`, which is a list of items to render (our todos), and `renderItem`, which is a callback to render our `Todo` item.
+`FlatList` accepts various properties, we will focus on 2 of them:
 
-> `renderItem` receives an object containing 2 keys: `item` and `index`, representing the current item in the list and its index, and must return a tree of elements.
+1. `data`, which represents the data we want to render.
+2. `renderItem`, which is expected to be a function. It receives an object containing 2 keys: `item` and `index`, representing the current item in the list and its index, and must return a tree of elements.
 
 We could reuse the same function we used with `todos.map()` earlier, as long as we change how we access the todos (the parameters are inside an object, you can destructure to access them directly).
 

--- a/slides.md
+++ b/slides.md
@@ -201,7 +201,7 @@ const Hello = ({name}) => (
 
 > The component will receive a parameter containing the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
 
-> You can then use the component importing it (if it was declared it in another file, remember to export it!) and using it as any other component.
+> You can then import your new component and use it as any other React component. If you declared the component in another file, make sure to export it!
 
 ```javascript
 <Hello name="Daniele" />

--- a/slides.md
+++ b/slides.md
@@ -172,7 +172,7 @@ Inside `render()`, you can then map those todos to a certain element:
 const todoElements = todos.map(todo => <Text>{todo.name}</Text>);
 ```
 
-> Inside a component you can include a JS expression with `{expression}`, in this case, `{todo.name}`.
+Inside a component you can include a JS expression with `{expression}`, in this case, `{todo.name}`.
 
 Since `todoElements` is an expression, we can include it inside our `View`, instead of the 3 `Text` elements, remember to use `{}`!
 
@@ -182,7 +182,7 @@ Since `todoElements` is an expression, we can include it inside our `View`, inst
 If you reloaded, you'll notice there's a small yellow warning on the bottom of the app. Components rendered with loops require a `key` property that identifies them.
 Keys are important for react to be able to understand which views have been added, removed or altered.
 
-> As you can do inside a component, you can use `propName={expression}` to pass properties. If it's a hardcoded string, prefer `propName="value"`.
+As you can do inside a component, you can use `propName={expression}` to pass properties. If it's a hardcoded string, prefer `propName="value"`.
 
 Before moving to the next step, let's use `todo.name` as a key for our elements.
 
@@ -199,7 +199,7 @@ const Hello = ({name}) => (
 );
 ```
 
-> The first argument of the function is the properties passed to the component. We're destructuring it and accessing `name` directly.
+The first argument of the function is the properties passed to the component. We're destructuring it and accessing `name` directly.
 
 You can then import your new component and use it as any other React component. If you declared the component in another file, make sure to export it!
 To pass props to a component, add them as an attribute when you use it.
@@ -208,7 +208,7 @@ To pass props to a component, add them as an attribute when you use it.
 <Hello name="Daniele" />
 ```
 
-> Note that, in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self-closing, and terminates with `/>` instead of just `>`.
+Note that, in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self-closing, and terminates with `/>` instead of just `>`.
 
 Extract a `TodoItem` component, that accepts a `name` parameter, and substitute the `Text`s with it.
 

--- a/slides.md
+++ b/slides.md
@@ -156,9 +156,9 @@ import anotherFunction, {aFunction} from "./someFile";
 
 ---
 # Hello Todo!
-Currently, `App.js` is quite boring, it would be great if instead of having the todos hardcoded, we could somehow cycle through an array of todos and show a `Text` per element.
+Currently, `App.js` is quite boring, it would be great if instead of having the TODOs hardcoded, we could somehow cycle through an array of TODOs and show a `Text` per element.
 
-First of all, we need to extract the data for the todos, in `App.js`:
+First of all, we need to extract the data for the TODOs, in `App.js`:
 ```javascript
 const todos = [{
     name: "Take the dog out",
@@ -166,7 +166,7 @@ const todos = [{
 ];
 ```
 
-Inside `render()`, you can then map those todos to a certain element:
+Inside `render()`, you can then map those TODOs to a certain element:
 
 ```javascript
 const todoElements = todos.map(todo => <Text>{todo.name}</Text>);
@@ -189,7 +189,7 @@ Before moving to the next step, let's use `todo.name` as a key for our elements.
 ---
 # Abstracting away
 
-Now that our single todo is well isolated, we can extract it to a separate component.
+Now that our single TODO is well isolated, we can extract it to a separate component.
 
 The simplest component (a **stateless** component) is a function that returns a tree of elements. It must have no side effects and return the same result given the same input.
 
@@ -214,7 +214,7 @@ Extract a `TodoItem` component, that accepts a `name` parameter, and substitute 
 
 ---
 # Lists
-Our to-do list is coming up quite well, but it won't scroll!
+Our TODO list is coming up quite well, but it won't scroll!
 
 There are a few possible solutions to it:
 
@@ -228,16 +228,16 @@ There are a few possible solutions to it:
 1. `data`, which represents the data we want to render.
 2. `renderItem`, which is expected to be a function. It receives an object containing 2 keys: `item` and `index`, representing the current item in the list and its index, and must return a tree of elements.
 
-We could reuse the same function we used with `todos.map()` earlier, as long as we change how we access the todos (the parameters are inside an object, you can destructure to access them directly).
+We could reuse the same function we used with `todos.map()` earlier, as long as we change how we access the TODOs (the parameters are inside an object, you can destructure to access them directly).
 
-Extract a `TodoList` element, that accepts a property `todos`, a list of todos, and uses `FlatList` to render `TodoItem`s.
+Extract a `TodoList` element, that accepts a property `todos`, a list of TODOs, and uses `FlatList` to render `TodoItem`s.
 
 ---
 # Lists - Keys
 
 You should now have another warning: `FlatList` needs to figure out the object key somehow. There are 2 ways of solving this.
 
-1. Add a unique `key` field to each one of our todos (the data).
+1. Add a unique `key` field to each one of our TODOs (the data).
 
 ```javascript
 const todos = [{
@@ -252,12 +252,12 @@ Pick one of the two options and get rid of the warning, then remove the property
 
 ---
 # State & co
-It's time to tick some todos, let's add a new field to them: `completed`, and set it to `false`.
+It's time to tick some TODOs, let's add a new field to them: `completed`, and set it to `false`.
 
 Now, let's add that to our properties in `Todo`, and let's use a `Switch` to display it. The property to tell a `Switch` if it's active or not is `value`.
 
 ---
-# Tick a todo! {.big}
+# Tick a TODO! {.big}
 
 ---
 # It lives..!
@@ -271,7 +271,7 @@ Now, let's add that to our properties in `Todo`, and let's use a `Switch` to dis
 # State - getting and initial
 To make the `Switch` work, we need to **change the state of our app**. React class components can be stateful, which means the `App` component can hold its state and React to events.
 
-To access the state in a component, you can use `this.state`. This means our `App` component can pass the todo list as a property to `TodoList`, receiving it from the state.
+To access the state in a component, you can use `this.state`. This means our `App` component can pass the TODO list as a property to `TodoList`, receiving it from the state.
 
 The initial state can be set in the constructor of a component, or alternatively `state = initialState` inside the class.
 

--- a/slides.md
+++ b/slides.md
@@ -156,7 +156,7 @@ import anotherFunction, {aFunction} from "./someFile";
 
 ---
 # Hello Todo!
-Currently `App.js` is quite boring, it would be great if instead of having the todos hardcoded, we could somehow cycle through an array of todos and show a `Text` per element.
+Currently, `App.js` is quite boring, it would be great if instead of having the todos hardcoded, we could somehow cycle through an array of todos and show a `Text` per element.
 
 First of all, we need to extract the data for the todos, in `App.js`:
 ```javascript

--- a/slides.md
+++ b/slides.md
@@ -232,9 +232,21 @@ Extract a `TodoList` element, that accepts a property `todos`, a list of todos, 
 
 ---
 # Lists - Keys
-You should now have another warning, `FlatList` needs to figure out the object key somehow, you can solve it two ways:
-1. Add a `key` field to our todos.
-2. Add a new property to `FlatList`: `keyExtractor`. It's a function that receives 2 parameters `(item, index)` and needs to return a `string` key, you could return `todo.name` here. This function isn't receiving an object, don't use the `{}`.
+
+You should now have another warning: `FlatList` needs to figure out the object key somehow. There are 2 ways of solving this.
+
+1. Add a unique `key` field to each one of our todos (the data).
+
+```javascript
+const todos = [{
+  name: "Take the dog out",
+  key: "abc"
+}];
+```
+
+2. Alternatively, we can pass an additional property to `TodoList`: `keyExtractor`. This is a function that receives 2 parameters: `item` and `index` (not inside an object this time), and needs to return a string representing the key of this element.
+
+Pick one of the two options and get rid of the warning, then remove the property `key` from the `TodoItem` element.
 
 ---
 # State & co

--- a/slides.md
+++ b/slides.md
@@ -187,11 +187,6 @@ Keys are important for react to be able to understand which views have been adde
 Before moving to the next step, let's use `todo.name` as a key for our elements.
 
 ---
-# Conventions
-- Sometimes I'll reference React Native components, such as `Text`. These can be imported with `import { ComponentName } from "react-native";`.
-- When you need to create a new component, save it in `ComponentName.js` and import it with `import { ComponentName } from "./ComponentName';`.
-
----
 # Abstracting away
 The app looks amazing! But it would be great to have a component `Todo` instead of using `Text`. The simplest components can be functions that accept properties and return other components, strings or `null`. Pay attention to the brackets for the function, we'll go over that next.
 ```javascript

--- a/slides.md
+++ b/slides.md
@@ -191,7 +191,7 @@ Before moving to the next step, let's use `todo.name` as a key for our elements.
 
 Now that our single todo is well isolated, we can extract it to a separate component.
 
-> The simplest component is a function that returns a tree of elements. It must have no side effects and return the same result given the same input.
+The simplest component (a **stateless** component) is a function that returns a tree of elements. It must have no side effects and return the same result given the same input.
 
 ```javascript
 const Hello = ({name}) => (
@@ -199,15 +199,16 @@ const Hello = ({name}) => (
 );
 ```
 
-> The component will receive a parameter containing the props passed to it, in this example `name` is one of the props `Hello` can accept, and we're using destructuring to access it directly.
+> The first argument of the function is the properties passed to the component. We're destructuring it and accessing `name` directly.
 
-> You can then import your new component and use it as any other React component. If you declared the component in another file, make sure to export it!
+You can then import your new component and use it as any other React component. If you declared the component in another file, make sure to export it!
+To pass props to a component, add them as an attribute when you use it.
 
 ```javascript
 <Hello name="Daniele" />
 ```
 
-> Note that in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self closing, and terminates with `/>` instead of just `>`.
+> Note that, in this case, since we don't accept children (components inside our component), the component has only one tag, which is called self closing, and terminates with `/>` instead of just `>`.
 
 Extract a `TodoItem` component, that accepts a `name` parameter, and substitute the `Text`s with it.
 

--- a/slides.md
+++ b/slides.md
@@ -246,7 +246,7 @@ const todos = [{
 }];
 ```
 
-2. Alternatively, we can pass an additional property to `TodoList`: `keyExtractor`. This is a function that receives 2 parameters: `item` and `index` (not inside an object this time), and needs to return a string representing the key of this element.
+2. Alternatively, we can pass an additional property to `TodoList`: `keyExtractor`. This is a function that receives two parameters: `item` and `index` (not inside an object this time), and needs to return a string representing the key of this element.
 
 Pick one of the two options and get rid of the warning, then remove the property `key` from the `TodoItem` element.
 

--- a/slides.md
+++ b/slides.md
@@ -174,7 +174,7 @@ const todoElements = todos.map(todo => <Text>{todo.name}</Text>);
 
 Inside a component you can include a JS expression with `{expression}`, in this case, `{todo.name}`.
 
-Since `todoElements` is an expression, we can include it inside our `View`, instead of the 3 `Text` elements, remember to use `{}`!
+Since `todoElements` is an expression, we can include it inside our `View`, instead of the 3 `Text` elements. Remember to use `{}`!
 
 ---
 # Keys in loops

--- a/slides.md
+++ b/slides.md
@@ -220,7 +220,7 @@ There are a few possible solutions to it:
 1. Using `ScrollView` instead of our `View` element would make it scrollable.
 2. Using `FlatList`, a similar concept to `RecyclerView` on Android and `UICollectionView` on iOS.
 
-`ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want it to be rendered when on screen. We will go with `FlatList`.
+`ScrollView` is usually picked when we have a fixed layout that might not fit in the container, `FlatList` is used when we have an arbitrary amount of data and we want to render only the components that are visible on screen. We will go with `FlatList`.
 
 > `FlatList` accepts various parameters, in our case we're interested in `data`, which is a list of items to render (our todos), and `renderItem`, which is a callback to render our `Todo` item.
 

--- a/slides.md
+++ b/slides.md
@@ -215,7 +215,7 @@ Extract a `TodoItem` component, that accepts a `name` parameter, and substitute 
 # Lists
 Our todo list is coming up quite well, but it won't scroll!
 
-There are a few possible solution to it:
+There are a few possible solutions to it:
 
 1. Using `ScrollView` instead of our `View` element would make it scrollable.
 2. Using `FlatList`, a similar concept to `RecyclerView` on Android and `UICollectionView` on iOS.


### PR DESCRIPTION
Moving from a slide format to a more tutorial format accessible from GH, this is because the slide format doesn't go well when we would like to have something to copy/paste, or a more detailed explanation.